### PR TITLE
� Fix API route imports for Render deploy // Renamed mediaNewsRouter …

### DIFF
--- a/server/src/routes/api/index.ts
+++ b/server/src/routes/api/index.ts
@@ -1,26 +1,23 @@
 import { Router } from 'express';
 import { userRouter } from './user-routes.js';
-import { mediaNewsRouter } from './mainNews.js';       // ✅ Mediastack route
-import { horoscopeRouter } from './horoscope.js';       // ✅ Aztro route
+import { mainNewsRouter } from './mainNews.js';        // ✅ Main News (Mediastack)
+import { horoscopeRouter } from './horoscope.js';      // ✅ Horoscope (Aztro)
 
-// ==============================
-// Create API Router
-// ==============================
 const router = Router();
 
 // ==============================
 // User Routes
 // ==============================
-router.use('/users', userRouter);                       // e.g. /api/users
+router.use('/users', userRouter);                      // e.g. /api/users
 
 // ==============================
 // Mediastack News Route
 // ==============================
-router.use('/media-news', mediaNewsRouter);             // e.g. /api/media-news/:category?
+router.use('/news', mainNewsRouter);                   // e.g. /api/news/:category?
 
 // ==============================
-// Horoscope Route (Aztro)
+// Horoscope Route
 // ==============================
-router.use('/horoscope', horoscopeRouter);              // e.g. /api/horoscope/:sign
+router.use('/horoscope', horoscopeRouter);             // e.g. /api/horoscope/:sign
 
 export default router;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -14,7 +14,7 @@ import express from 'express';
 
 import sequelize from './config/connection.js';
 import routes from './routes/index.js';
-import { mediaNewsRouter } from './routes/api/mainNews.js'; // ✅ UPDATED
+import { mainNewsRouter } from './routes/api/mainNews.js'; // ✅ FIXED: Correct export name
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -37,7 +37,7 @@ app.use(express.static('../client/dist'));
 // ==============================
 // TODO: Custom Routes
 // ==============================
-app.use('/api/media-news', mediaNewsRouter); // ✅ New Mediastack route
+app.use('/api/news', mainNewsRouter); // ✅ FIXED to match export
 app.use(routes);
 
 // ==============================


### PR DESCRIPTION
…to mainNewsRouter for Mediastack // Linked Horoscope route correctly